### PR TITLE
Updated Script URLs

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ For now, the script can be included directly from GitHub via RawGit, either thro
 ### Script tag
 
 ```html
-<script src="https://cdn.rawgit.com/renehamburger/blinx.js/v0.3.15/dist/blinx.js" defer data-blinx="{
+<script src="https://cdn.statically.io/gh/benjaminwolkchen/blinx.js/fd8671c0/dist/blinx.js" defer data-blinx="{
   language: 'de'
 }"></script>
 ```
@@ -35,8 +35,8 @@ The `data-blinx` attribute contains the options for blinx.js. For now, look at t
 blinx.js loads several resources it requires dynamically and asynchronously. To speed up the identification and linking of Bible references on the page, the following script can already be loaded in parallel to blinx.js:
 
 ```html
-<script src="https://cdn.rawgit.com/renehamburger/Bible-Passage-Reference-Parser/99f03385/js/<LANGUAGE_CODE>_bcv_parser.js" defer></script>
-<script src="https://cdn.rawgit.com/renehamburger/blinx.js/v0.3.15/dist/blinx.js" defer></script>
+<script src="https://cdn.statically.io/gh/benjaminwolkchen/Bible-Passage-Reference-Parser/99f03385/js/<LANGUAGE_CODE>_bcv_parser.js" defer></script>
+<script src="https://cdn.statically.io/gh/benjaminwolkchen/blinx.js/fd8671c0/dist/blinx.js" defer></script>
 ```
 
 The string entered for the `<LANGUAGE_CODE>`, e.g. 'de', will then also determine the language for blinx.js. ('537560a7' is the current [latest commit of the Bible Passage Reference Parser](https://github.com/openbibleinfo/Bible-Passage-Reference-Parser/commits/master) and may need to be updated at a later stage.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # blinx.js
 
 [![Build Status](https://travis-ci.org/renehamburger/blinx.js.svg?branch=master)](https://travis-ci.org/renehamburger/blinx.js)
-[![BrowserStack Status](https://automate.browserstack.com/badge.svg?badge_key=ZHZXSFIyYWxaWGtWNm51K3JqRjZrRnlXa09yWEVJSlYwU0NtZHIrZnZOST0tLU9wRkRiRmZEbExsMXZpVElGQW5veGc9PQ==--336cefaa74253fa87033e03f7e84663ee369c225)](https://automate.browserstack.com/public-build/ZHZXSFIyYWxaWGtWNm51K3JqRjZrRnlXa09yWEVJSlYwU0NtZHIrZnZOST0tLU9wRkRiRmZEbExsMXZpVElGQW5veGc9PQ==--336cefaa74253fa87033e03f7e84663ee369c225)
 [![codecov](https://codecov.io/gh/renehamburger/blinx.js/branch/master/graph/badge.svg)](https://codecov.io/gh/renehamburger/blinx.js)
 <a href="#browser-compatibility--test"><img src="https://badges.herokuapp.com/browsers?labels=none&googlechrome=latest&firefox=latest&microsoftedge=latest&iexplore=-9,10,11&safari=latest" alt="Browser Support"/></a>
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ For now, the script can be included directly from GitHub via RawGit, either thro
 ### Script tag
 
 ```html
-<script src="https://cdn.statically.io/gh/benjaminwolkchen/blinx.js/fd8671c0/dist/blinx.js" defer data-blinx="{
+<script src="https://cdn.statically.io/gh/renehamburger/blinx.js/fd8671c0/dist/blinx.js" defer data-blinx="{
   language: 'de'
 }"></script>
 ```
@@ -34,8 +34,8 @@ The `data-blinx` attribute contains the options for blinx.js. For now, look at t
 blinx.js loads several resources it requires dynamically and asynchronously. To speed up the identification and linking of Bible references on the page, the following script can already be loaded in parallel to blinx.js:
 
 ```html
-<script src="https://cdn.statically.io/gh/benjaminwolkchen/Bible-Passage-Reference-Parser/99f03385/js/<LANGUAGE_CODE>_bcv_parser.js" defer></script>
-<script src="https://cdn.statically.io/gh/benjaminwolkchen/blinx.js/fd8671c0/dist/blinx.js" defer></script>
+<script src="https://cdn.statically.io/gh/renehamburger/Bible-Passage-Reference-Parser/99f03385/js/<LANGUAGE_CODE>_bcv_parser.js" defer></script>
+<script src="https://cdn.statically.io/gh/renehamburger/blinx.js/fd8671c0/dist/blinx.js" defer></script>
 ```
 
 The string entered for the `<LANGUAGE_CODE>`, e.g. 'de', will then also determine the language for blinx.js. ('537560a7' is the current [latest commit of the Bible Passage Reference Parser](https://github.com/openbibleinfo/Bible-Passage-Reference-Parser/commits/master) and may need to be updated at a later stage.
@@ -45,7 +45,7 @@ The string entered for the `<LANGUAGE_CODE>`, e.g. 'de', will then also determin
 ```js
 var blinxScript = document.createElement("script");
 blinxScript.type = 'text/javascript';
-blinxScript.src = 'https://cdn.statically.io/gh/benjaminwolkchen/blinx.js/fd8671c0/dist/blinx.js';
+blinxScript.src = 'https://cdn.statically.io/gh/renehamburger/blinx.js/fd8671c0/dist/blinx.js';
 document.documentElement.appendChild(blinxScript);
 blinxScript.setAttribute('data-blinx', '{ language: "de" }');
 ```

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ The string entered for the `<LANGUAGE_CODE>`, e.g. 'de', will then also determin
 ```js
 var blinxScript = document.createElement("script");
 blinxScript.type = 'text/javascript';
-blinxScript.src = 'https://cdn.rawgit.com/renehamburger/blinx.js/v0.3.15/dist/blinx.js';
+blinxScript.src = 'https://cdn.statically.io/gh/benjaminwolkchen/blinx.js/fd8671c0/dist/blinx.js';
 document.documentElement.appendChild(blinxScript);
 blinxScript.setAttribute('data-blinx', '{ language: "de" }');
 ```

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ For now, the script can be included directly from GitHub via RawGit, either thro
 ### Script tag
 
 ```html
-<script src="https://cdn.jsdelivr.net/gh/renehamburger/blinx.js/fd8671c0/dist/blinx.js" defer data-blinx="{
+<script src="https://cdn.jsdelivr.net/gh/renehamburger/blinx.js/dist/blinx.js" defer data-blinx="{
   language: 'de'
 }"></script>
 ```
@@ -34,8 +34,8 @@ The `data-blinx` attribute contains the options for blinx.js. For now, look at t
 blinx.js loads several resources it requires dynamically and asynchronously. To speed up the identification and linking of Bible references on the page, the following script can already be loaded in parallel to blinx.js:
 
 ```html
-<script src="https://cdn.jsdelivr.net/gh/renehamburger/Bible-Passage-Reference-Parser/99f03385/js/<LANGUAGE_CODE>_bcv_parser.js" defer></script>
-<script src="https://cdn.jsdelivr.net/gh/renehamburger/blinx.js/fd8671c0/dist/blinx.js" defer></script>
+<script src="https://cdn.jsdelivr.net/gh/renehamburger/Bible-Passage-Reference-Parser/js/<LANGUAGE_CODE>_bcv_parser.js" defer></script>
+<script src="https://cdn.jsdelivr.net/gh/renehamburger/blinx.js/dist/blinx.js" defer></script>
 ```
 
 The string entered for the `<LANGUAGE_CODE>`, e.g. 'de', will then also determine the language for blinx.js. ('537560a7' is the current [latest commit of the Bible Passage Reference Parser](https://github.com/openbibleinfo/Bible-Passage-Reference-Parser/commits/master) and may need to be updated at a later stage.
@@ -45,7 +45,7 @@ The string entered for the `<LANGUAGE_CODE>`, e.g. 'de', will then also determin
 ```js
 var blinxScript = document.createElement("script");
 blinxScript.type = 'text/javascript';
-blinxScript.src = 'https://cdn.jsdelivr.net/gh/renehamburger/blinx.js/fd8671c0/dist/blinx.js';
+blinxScript.src = 'https://cdn.jsdelivr.net/gh/renehamburger/blinx.js/dist/blinx.js';
 document.documentElement.appendChild(blinxScript);
 blinxScript.setAttribute('data-blinx', '{ language: "de" }');
 ```

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ For now, the script can be included directly from GitHub via RawGit, either thro
 ### Script tag
 
 ```html
-<script src="https://cdn.statically.io/gh/renehamburger/blinx.js/fd8671c0/dist/blinx.js" defer data-blinx="{
+<script src="https://cdn.jsdelivr.net/gh/renehamburger/blinx.js/fd8671c0/dist/blinx.js" defer data-blinx="{
   language: 'de'
 }"></script>
 ```
@@ -34,8 +34,8 @@ The `data-blinx` attribute contains the options for blinx.js. For now, look at t
 blinx.js loads several resources it requires dynamically and asynchronously. To speed up the identification and linking of Bible references on the page, the following script can already be loaded in parallel to blinx.js:
 
 ```html
-<script src="https://cdn.statically.io/gh/renehamburger/Bible-Passage-Reference-Parser/99f03385/js/<LANGUAGE_CODE>_bcv_parser.js" defer></script>
-<script src="https://cdn.statically.io/gh/renehamburger/blinx.js/fd8671c0/dist/blinx.js" defer></script>
+<script src="https://cdn.jsdelivr.net/gh/renehamburger/Bible-Passage-Reference-Parser/99f03385/js/<LANGUAGE_CODE>_bcv_parser.js" defer></script>
+<script src="https://cdn.jsdelivr.net/gh/renehamburger/blinx.js/fd8671c0/dist/blinx.js" defer></script>
 ```
 
 The string entered for the `<LANGUAGE_CODE>`, e.g. 'de', will then also determine the language for blinx.js. ('537560a7' is the current [latest commit of the Bible Passage Reference Parser](https://github.com/openbibleinfo/Bible-Passage-Reference-Parser/commits/master) and may need to be updated at a later stage.
@@ -45,7 +45,7 @@ The string entered for the `<LANGUAGE_CODE>`, e.g. 'de', will then also determin
 ```js
 var blinxScript = document.createElement("script");
 blinxScript.type = 'text/javascript';
-blinxScript.src = 'https://cdn.statically.io/gh/renehamburger/blinx.js/fd8671c0/dist/blinx.js';
+blinxScript.src = 'https://cdn.jsdelivr.net/gh/renehamburger/blinx.js/fd8671c0/dist/blinx.js';
 document.documentElement.appendChild(blinxScript);
 blinxScript.setAttribute('data-blinx', '{ language: "de" }');
 ```


### PR DESCRIPTION
EN: Updated script URLs to statically.io CDN because rawgit.com is sunsetting its service.

DE: Script URLs aktualisiert weil rawgit.com nicht mehr fortgeführt wird / den CDN Service anbietet.